### PR TITLE
Upgrades tls certs to *strongly recommended*

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -43,7 +43,7 @@ Concourse Operations Lifecycle Management (OLM) for Pivotal Cloud Foundry (PCF) 
  <li>Prepare the Concourse deployment manifest. You can write your own manifest, or <a href="LINK TO PIVNET TEMPLATE">modify a template</a> with your unique configuration.<br/>
  <p class="note"><strong>Note</strong>: By default, the deployment manifest does not provide any authorization configuration. Follow the instructions in <a href="./authorizing.html">Authorization</a> to configure authorization protocols.<br />
 
-Additionally, if you want to use your own trusted Certificate Authority (CA) and certificate, provide `tls_cert` and `tls_key` values in the manifest.</p></li>  
+We strongly recommend using CA-trusted Certificate - provide `tls_cert` and `tls_key` values in the manifest. The fly cli login command --ca-cert flag supports supplying the expected certificate for added security. </p></li>  
  <li>Prepare the cloud-config.yml file.<br/>
 <p class="note"><strong>Note</strong>: If you refer to a specific configuration parameter in your deployment manifest, you must specify its value in the cloud-config.yml.</p></li>
 <li>Open a terminal window.</li>


### PR DESCRIPTION
if they want to use self-signed certs they can use `fly login --ca-cert` so that they don't have to accept all certs willy-nilly. But we probably shouldn't mention it?