### PR TITLE
Update authenticating.html.md.erb

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -37,7 +37,7 @@ The following table describes the function of each Concourse component:
     <td><b>TSA</b></td>
     <td>Runs an SSH server that:
       <ul><li>Listens on port 2222.</li>
-      <li>Securely <a href="https://concourse-ci.org/components.html#component-tsa">registers worker VMs</a> for use by the ATC.</li>
+      <li>Securely <a href="https://concourse-ci.org/concepts.html#component-tsa">registers worker VMs</a> for use by the ATC.</li>
       <li>For <a href="#comms-external">external worker</a> VMs, handshakes with Beacon to open a reverse SSH tunnel for ongoing communication between the ATC and the worker.</li>
       <li>Pings workers for heartbeat every 30 seconds, updates ATC with worker metric changes, and,
           if there is no response, notifies ATC that the worker is in a <code>stalled</code> state.</li></ul>

--- a/authenticating.html.md.erb
+++ b/authenticating.html.md.erb
@@ -103,17 +103,28 @@ Configure a client for Concourse with your UAA. The callback URL is the external
 An example client is below. This client should be stored under [uaa.clients](http://bosh.io/jobs/uaa?source=github.com/cloudfoundry/uaa-release&version=13#p=uaa.clients):
 
 <pre class="terminal">
-concourse:
-  id: MY-CLIENT-ID
-  secret: MY-CLIENT-SECRET
+uaac client add MY-CLIENT-ID \
+  --name MY-CLIENT-ID \
+  --scope cloud_controller.read \
+  --authorized_grant_types "authorization_code,refresh_token" \
+  --access_token_validity 3600 \
+  --refresh_token_validity 3600 \
+  --secret MY-CLIENT-SECRET \     
+  --redirect_uri https://concourse.example.com/auth/uaa/callback
+</pre>
+
+<pre class="terminal">
   scope: cloud_controller.read
+  client_id: MY-CLIENT-ID
+  resource_ids: none
+  authorized_grant_types: refresh_token authorization_code
+  redirect_uri: https://concourse.example.com/auth/uaa/callback
+  autoapprove:
+  access_token_validity: 3600
+  refresh_token_validity: 3600
   authorities: cloud_controller.admin
-  authorized-grant-types: "authorization_code,client_credentials,refresh_token"
-  access-token-validity: 3600
-  refresh-token-validity: 3600
-  autoapprove: true
-  override: true
-  redirect-uri: https://concourse.EXAMPLE.com/auth/uaa/callback
+  name: MY-CLIENT-ID
+  lastmodified: 1532640432000
 </pre>
 
 ### <a id="team"></a> Configuring the Team


### PR DESCRIPTION
The existing uaac output of client info is wrong, There is no --override option when creating a client. Also, Providing the uaa command helps as there are typos in the manner uaa grant types listed in the existing document versus the actual output.

The proposed changes are validated and followed from the general Github link

https://github.com/pivotalservices/concourse-pipeline-samples/tree/master/concourse-pipeline-patterns/uaa-authentication