### PR TITLE
Updated 3.13 notes for run c

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -75,8 +75,8 @@ For more information, see <a href="./troubleshooting.html">Troubleshooting</a>.
 |       v3.6.0      |  1.9.0 | 9.5+ External |       3468       |      3468.*          |      1.3.x      |
 |       v3.8.0      |  1.9.0 | 9.5+ External |      3468.11     |      3468.*          |      1.3.x      |
 |       v3.9.2      | 1.12.0 | 9.5+ External |      3468.22     |      3468.*          |      1.7.1      |
-|       v3.13.0     | 1.13.1 | 9.5+ External |      3541.12     |      3541.*          |      1.8.3      |
-|       v3.13.2     | 1.18.2 | 9.5+ External |      3541.12     |      3541.*          |      1.8.3      |
+|       v3.13.0     | 1.18.2 | 9.5+ External |      250.9     |      250.*          |      1.8.3      |
+
 
 <p class="note"><strong>Note:</strong> The value under the "Tested" columns indicate
   that Concourse was tested with the listed stemcell or product version upon release.

--- a/rn.html.md.erb
+++ b/rn.html.md.erb
@@ -5,18 +5,14 @@ owner: Concourse
 
 <strong><%= modified_date %></strong>
 
-## <a id="release-notes"></a> Release Notes for Concourse v3.13.2
-<strong>Release Date: February 20, 2019</strong>
+## <a id="release-notes"></a> Release Notes for Concourse v3.13.0
+<strong>Release Date: June 4, 2018</strong>
 
 ###<a id="security-3132"></a> Security Fixes
 This release contains the following security fix:
 
 * High [CVE 2019-5736: runC container breakout](https://pivotal.io/security/cve-2019-5736)
-  * Added compatibility with Garden RunC v1.18.2 to address this.
-
-
-## <a id="release-notes"></a> Release Notes for Concourse v3.13.0
-<strong>Release Date: June 4, 2018</strong>
+  * Update Garden RunC to v1.18.2 and bump your stemcells to xenial 250.x to address this.
 
 ###<a id="bosh-release"></a>BOSH Release
 The `groundcrew` job has been renamed to `worker` in this release of Concourse;


### PR DESCRIPTION
These changes should override the previous changes made to the 3.x branch. Don't push until you get approval from JM or SF. 