### PR TITLE
Correct link to Concourse components doc

### DIFF
--- a/architecture.html.md.erb
+++ b/architecture.html.md.erb
@@ -70,7 +70,7 @@ The following table describes the function of each Concourse component:
   </tr>
 </table>
 
-For more information, see the [Concourse Documentation](https://concourse-ci.org/components.html).
+For more information, see the [Concourse Documentation](https://concourse-ci.org/concepts.html).
 
 ## <a id="comms"></a> Internal vs. External Workers
 


### PR DESCRIPTION
Had a client point out that the old link returns an HTTP 404