### PR TITLE
Updating compatibility matrix for 4.2.4

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -70,9 +70,10 @@ For more information, see <a href="./troubleshooting.html">Troubleshooting</a>.
 ## <a id="compatibility"></a>Concourse Compatibility
 | Concourse Version |  RunC  |   PostgreSQL  | Tested Stemcell  |  Supported Stemcells | Tested CredHub  |
 |:-----------------:|:------:|:-------------:|:----------------:|:--------------------:|:---------------:|
-|       v4.2.1      | 1.16.3 | 9.5+ External |      Xenial 97.16   |      97.x            |      1.9.5      |
-|       v4.2.2      | 1.16.0 & 1.17.2 | 9.5+ External |      Xenial 97 & 170.13  |      97.x & 170.x          |      1.9.5      |
-|       v4.2.3      | 1.18.2 | 9.5+ External |      Xenial 250.9  |      250.x          |      1.9.5      |
+|       v4.2.1      | 1.16.3 | 9.6 External |      Xenial 97.16   |      97.x            |      1.9.5      |
+|       v4.2.2      | 1.16.0 & 1.17.2 | 9.6 External |      Xenial 97 & 170.13  |      97.x & 170.x          |      1.9.5      |
+|       v4.2.3      | 1.18.2 | 9.6 External |      Xenial 250.9  |      250.x          |      1.9.5      |
+|       v4.2.4      | 1.18.2 | 9.6 External |      Xenial 250.38  |      250.x          |      1.9.5      |
 
 <p class="note"><strong>Note:</strong> The values in the "Tested" columns indicate
   that Concourse was tested with the listed stemcell or product version upon release.


### PR DESCRIPTION
Updated compatibility matrix for 4.2.4. Do not push to prod until SF gives the go ahead. 