### PR TITLE
Updated link to RBAC Configuring Users

### DIFF
--- a/rn.html.md.erb
+++ b/rn.html.md.erb
@@ -21,7 +21,7 @@ Currently, there are five defined roles:
 These roles evolved out of the common request of having a read-only team member.
 A slightly less powerful `team member` role was added as well.
 For more information about RBAC roles and how they impact authentication,
-see [Configuring Local Users](./authenticating/local-auth.html).
+see [Set User Roles and Permissions](./authenticating/github-auth.html#user-roles-and-permissions).
 
 <hr style="height:1px;border:none;color:#333;background-color:#333;" />
 ##<a id="security-520"></a> Security Fixes


### PR DESCRIPTION
Changed RBAC link in the release notes so that it points to Github.