### PR TITLE
Updated Compatibility Matrix

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -70,6 +70,7 @@ To troubleshoot your Concourse for PCF installation, see <a href="./troubleshoot
 |:-----------------:|:-------------:|:----------------:|:--------------------:|:---------------:|
 |       v5.2.0      | 9.6+ External |   Xenial 315.26  |      315.x           |      2.4.0      |
 |       v5.2.1      | 9.6+ External |   Xenial 315.26  |      315.x           |      2.4.0      |
+|       v5.2.2      | 9.6+ External |   Xenial 315.26  |      315.x           |      2.4.0      |
 
 <p class="note warning"><strong>Warning: </strong>If you are using PostgreSQL v11.1 or v11.2, set
 <code>max_parallel_workers_per_gather</code> to <code>0</code>. This corrects a PostgreSQL infinite parallel


### PR DESCRIPTION
Added 5.2.2 to the compatibility matrix. Do not push to prod until given the word from SF.