### PR TITLE
Updated Compatibility Matrix

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -73,6 +73,7 @@ For more information, see <a href="./troubleshooting.html">Troubleshooting</a>.
 |       v4.2.2      | 1.16.0 & 1.17.2 | 9.5+ External |      Xenial 97 & 170.13  |      97.x & 170.x          |      1.9.5      |
 |       v4.2.3      | 1.18.2 | 9.5+ External |      Xenial 250.9  |      250.x          |      1.9.5      |
 |       v4.2.4      | 1.19.1 | 9.5+ External |      Xenial 250.38  |      250.x          |      1.9.5      |
+|       v4.2.5      | 1.19.1 | 9.5+ External |      Xenial 250.38  |      250.x          |      1.9.5      |
 
 <p class="note warning"><strong>Warning: </strong>If you are using PostgreSQL v11.1 or v11.2, you must set
 <code>max_parallel_workers_per_gather</code> to <code>0</code>.


### PR DESCRIPTION
Updated compatibility matrix with 4.2.5. Do not push live until given permission by SF.